### PR TITLE
SystemState.BeforeOnUpdate.Complete() removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 This fork provides performance optimizations, quick fixes, and improvements to the entities package. It will never add new features. Therefore, as long as you depend on some obscure behavior, you should always be able to switch between the official package and this fork without any issues.
 
 ## Changes
+- SystemState.BeforeOnUpdate.Complete() removed to stop sync points in fixed updated. Replaced with CompleteWorldDependencySystem.
 
 # About Entities
 The Entities package provides a modern Entity Component System (ECS) implementation with a basic set of systems and components made for Unity.

--- a/Unity.Entities/CompleteWorldDependencySystem.cs
+++ b/Unity.Entities/CompleteWorldDependencySystem.cs
@@ -1,0 +1,49 @@
+﻿// <copyright file="CompleteWorldDependencySystem.cs" company="BovineLabs">
+//     Copyright (c) BovineLabs. All rights reserved.
+// </copyright>
+
+namespace Unity.Entities
+{
+    using Unity.Burst;
+    using Unity.Collections;
+    using Unity.Jobs;
+    using UnityEngine.Scripting;
+
+    [Preserve]
+    [UpdateInGroup(typeof(InitializationSystemGroup))]
+    [WorldSystemFilter(WorldSystemFilterFlags.Default | WorldSystemFilterFlags.ThinClientSimulation | WorldSystemFilterFlags.Editor)]
+    public unsafe partial struct CompleteWorldDependencySystem : ISystem
+    {
+        private NativeList<JobHandle> m_dependencies;
+        private JobHandle m_dependency;
+
+        [BurstCompile]
+        public void OnCreate(ref SystemState state)
+        {
+            m_dependencies = new NativeList<JobHandle>(128, Allocator.Persistent);
+        }
+
+        [BurstCompile]
+        public void OnDestroy(ref SystemState state)
+        {
+            m_dependencies.Dispose();
+        }
+
+        [BurstCompile]
+        public void OnUpdate(ref SystemState state)
+        {
+            m_dependency.Complete();
+
+            using var e = state.WorldUnmanaged.GetImpl().m_SystemStatePtrMap.GetEnumerator();
+            while (e.MoveNext())
+            {
+                var systemState = (SystemState*)e.Current.Value;
+                this.m_dependencies.Add(systemState->m_JobHandle);
+            }
+
+            // This seems slightly faster than doing JobHandle.CompleteAll()
+            m_dependency = JobHandle.CombineDependencies(m_dependencies.AsArray());
+            m_dependencies.Clear();
+        }
+    }
+}

--- a/Unity.Entities/CompleteWorldDependencySystem.cs.meta
+++ b/Unity.Entities/CompleteWorldDependencySystem.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 22f44607f3204183be69a49b264ae7ae
+timeCreated: 1695942828

--- a/Unity.Entities/SystemState.cs
+++ b/Unity.Entities/SystemState.cs
@@ -412,9 +412,9 @@ namespace Unity.Entities
                 {
                     var depMgr = m_DependencyManager;
                     NeedToGetDependencyFromSafetyManager = false;
-                    m_JobHandle = depMgr->GetDependency(m_JobDependencyForReadingSystems.Ptr,
+                    m_JobHandle = JobHandle.CombineDependencies(m_JobHandle, depMgr->GetDependency(m_JobDependencyForReadingSystems.Ptr,
                         m_JobDependencyForReadingSystems.Length, m_JobDependencyForWritingSystems.Ptr,
-                        m_JobDependencyForWritingSystems.Length);
+                        m_JobDependencyForWritingSystems.Length));
                 }
 
                 return m_JobHandle;
@@ -585,7 +585,7 @@ namespace Unity.Entities
 
             // We need to wait on all previous frame dependencies, otherwise it is possible that we create infinitely long dependency chains
             // without anyone ever waiting on it
-            m_JobHandle.Complete();
+            // m_JobHandle.Complete();
             NeedToGetDependencyFromSafetyManager = true;
         }
 


### PR DESCRIPTION
SystemState.BeforeOnUpdate.Complete() removed to stop sync points in fixed updated. Replaced with CompleteWorldDependencySystem.